### PR TITLE
Better hostname and domain name querying

### DIFF
--- a/src/running/util.py
+++ b/src/running/util.py
@@ -105,8 +105,8 @@ class MomaReservaton(object):
 class Moma(object):
     def __init__(self, host: Optional[str] = None, frequency: int = 60):
         if host is None:
-            self.host = socket.gethostname()
-            self.is_moma = socket.getfqdn().endswith(".moma")
+            self.host = system("hostname -s").strip()
+            self.is_moma = system("hostname -d").strip() == "moma"
         else:
             self.host = host
             try:


### PR DESCRIPTION
The methods from the standard library don't seem to be robust (at least dodgy in environments where hostname and domain name are given by DHCP servers). The fix should be UNIX-like compatible.

https://stackoverflow.com/questions/56442873/socket-getfqdn-returns-no-domain-but-socket-gethostname-does

https://github.com/systemd/systemd/issues/20358