### PR TITLE
Fix limited buffer size when using pty

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,11 @@
 
 ### Security
 
+## [`v0.3.8` (2023-02-21)](https://github.com/anupli/running-ng/releases/tag/v0.3.8)
+### Changed
+#### Commands
+- `runbms`: companion programs are now expected to self-terminate.
+
 ## [`v0.3.7` (2023-02-14)](https://github.com/anupli/running-ng/releases/tag/v0.3.7)
 ### Fixed
 #### Commands

--- a/docs/src/references/suite.md
+++ b/docs/src/references/suite.md
@@ -67,9 +67,10 @@ Second, a dictionary of strings with shell-like syntax to specify possibly diffe
 If a benchmark doesn't have a wrapper in the dictionary, it is treated as `null`.
 
 `companion` (preview ⚠️): the syntax is similar to `wrapper`.
-The companion program will start before the main program and run in a separate terminal.
+The companion program will start before the main program.
 The main program will start two seconds after the companion program to make sure the companion is fully initialized.
-Once the main program finishes, `^C` is sent to the terminal to stop the companion program.
+Once the main program finishes, we will wait for the companion program to finish.
+Therefore, companion programs should have appropriate timeouts or detect when main program finishes.
 Here is an example of using `companion` to launch `bpftrace` in the background to count the system calls.
 ```yaml
 includes:
@@ -77,7 +78,7 @@ includes:
 
 overrides:
   "suites.dacapo2006.timing_iteration": 1
-  "suites.dacapo2006.companion": "sudo bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @syscall[args->id] = count(); @process[comm] = count();} END { printf(\"Goodbye world!\\n\"); }'"
+  "suites.dacapo2006.companion": "sudo bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @syscall[args->id] = count(); @process[comm] = count();} interval:s:10 { printf(\"Goodbye world!\\n\"); exit(); }'"
   "invocations": 1
 
 benchmarks:

--- a/src/running/__version__.py
+++ b/src/running/__version__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 3, 7)
+VERSION = (0, 3, 8)
 __VERSION__ = '.'.join(map(str, VERSION))

--- a/src/running/benchmark.py
+++ b/src/running/benchmark.py
@@ -95,13 +95,9 @@ class Benchmark(object):
             companion_out = b""
             stdout: Optional[bytes]
             if self.companion:
-                pid, fd = pty.fork()
-                if pid == 0:
-                    os.execvp(self.companion[0], self.companion)
+                companion_p = subprocess.Popen(self.companion, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                sleep(COMPANION_WAIT_START)
             try:
-                if self.companion:
-                    # Wait for the companion program to start
-                    sleep(COMPANION_WAIT_START)
                 p = subprocess.run(
                     cmd,
                     env=env_args,
@@ -120,25 +116,18 @@ class Benchmark(object):
                 stdout = e.stdout
             finally:
                 if self.companion:
-                    # send ^C to the companion's controlling terminal
-                    # this is so that we can terminal setuid programs like sudo
-                    os.write(fd, b"\x03")
-                    while True:
+                    try:
+                        companion_stdout, _ = companion_p.communicate(timeout=1)
+                        companion_out += companion_stdout
+                    except subprocess.TimeoutExpired:
+                        logging.warning("Companion program not exited after 10 seconds timeout. Trying to kill ...")
                         try:
-                            output = os.read(fd, 1024)
-                            if not output:
-                                break
-                            companion_out += output
-                        except OSError as e:
-                            if e.errno == errno.EIO:
-                                break
-                    pid_wait, status = os.waitpid(pid, 0)
-                    assert pid_wait == pid
-                    exitcode = os.waitstatus_to_exitcode(status)
-                    if exitcode != 0:
-                        logging.warning(
-                            "Exit code {} for the companion process".format(exitcode))
-                    os.close(fd)
+                            companion_p.kill()
+                        except PermissionError:
+                            logging.warning("Failed to kill.")
+                        companion_stdout, _ = companion_p.communicate()
+                        companion_out += companion_stdout
+                
             return stdout if stdout else b"", companion_out, subprocess_exit
 
 

--- a/src/running/benchmark.py
+++ b/src/running/benchmark.py
@@ -95,7 +95,8 @@ class Benchmark(object):
             companion_out = b""
             stdout: Optional[bytes]
             if self.companion:
-                companion_p = subprocess.Popen(self.companion, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                companion_p = subprocess.Popen(
+                    self.companion, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 sleep(COMPANION_WAIT_START)
             try:
                 p = subprocess.run(
@@ -117,17 +118,19 @@ class Benchmark(object):
             finally:
                 if self.companion:
                     try:
-                        companion_stdout, _ = companion_p.communicate(timeout=1)
+                        companion_stdout, _ = companion_p.communicate(
+                            timeout=10)
                         companion_out += companion_stdout
                     except subprocess.TimeoutExpired:
-                        logging.warning("Companion program not exited after 10 seconds timeout. Trying to kill ...")
+                        logging.warning(
+                            "Companion program not exited after 10 seconds timeout. Trying to kill ...")
                         try:
                             companion_p.kill()
                         except PermissionError:
                             logging.warning("Failed to kill.")
                         companion_stdout, _ = companion_p.communicate()
                         companion_out += companion_stdout
-                
+
             return stdout if stdout else b"", companion_out, subprocess_exit
 
 


### PR DESCRIPTION
`bpftrace` outputs are sometimes truncated when too long, but everything after `^c` is still there. It's just too fragile. Let's use Popen for now.